### PR TITLE
Release v2.3.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
 Requires at least: 4.4
 Tested up to: 4.9.7
-Stable Tag: 2.3.4
+Stable Tag: 2.3.5-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -153,6 +153,8 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 `
 
 == Changelog ==
+
+= 2019.nn.nn - version 2.3.5-dev.1 =
 
 = 2018.07.17 - version 2.3.4 =
  * Misc - Remove support for WooCommerce 2.5

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,8 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 == Changelog ==
 
 = 2019.nn.nn - version 2.3.5-dev.1 =
+ * Tweak - Ensure generated SKUs are unique before saving
+ * Fix - Prevent errors when saving invalid SKUs
 
 = 2018.07.17 - version 2.3.4 =
  * Misc - Remove support for WooCommerce 2.5

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -421,9 +421,18 @@ class WC_SKU_Generator {
 		if ( 'never' !== get_option( 'wc_sku_generator_simple' ) ) {
 
 			if ( self::is_wc_version_gte_3_0() ) {
-				$product->set_sku( $product_sku );
-				$product->save();
+
+				$product_sku = wc_product_generate_unique_sku( $product->get_id(), $product_sku );
+
+				try {
+
+					$product->set_sku( $product_sku );
+					$product->save();
+
+				} catch ( \WC_Data_Exception $exception ) {}
+
 			} else {
+
 				update_post_meta( $product->get_id(), '_sku', $product_sku );
 			}
 		}
@@ -461,9 +470,18 @@ class WC_SKU_Generator {
 			$sku = apply_filters( 'wc_sku_generator_variation_sku_format', $sku, $parent_sku, $variation_sku );
 
 			if ( self::is_wc_version_gte_3_0() ) {
-				$variation->set_sku( $sku );
-				$variation->save();
+
+				try {
+
+					$sku = wc_product_generate_unique_sku( $variation_id, $sku );
+
+					$variation->set_sku( $sku );
+					$variation->save();
+
+				} catch ( \WC_Data_Exception $exception ) {}
+
 			} else {
+
 				update_post_meta( $variation_id, '_sku', $sku );
 			}
 		}

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -9,7 +9,7 @@
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2014-2018 SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2014-2019 SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -17,7 +17,7 @@
  * @package   WC-Product-SKU-Generator
  * @author    SkyVerge
  * @category  Admin
- * @copyright Copyright (c) 2014-2018, SkyVerge, Inc.
+ * @copyright Copyright (c) 2014-2019, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 2.6.14
@@ -63,7 +63,7 @@ class WC_SKU_Generator {
 
 
 	/** plugin version number */
-	const VERSION = '2.3.4';
+	const VERSION = '2.3.5-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '2.6.14';

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -429,7 +429,7 @@ class WC_SKU_Generator {
 					$product->set_sku( $product_sku );
 					$product->save();
 
-				} catch ( \WC_Data_Exception $exception ) {}
+				} catch ( WC_Data_Exception $exception ) {}
 
 			} else {
 
@@ -478,7 +478,7 @@ class WC_SKU_Generator {
 					$variation->set_sku( $sku );
 					$variation->save();
 
-				} catch ( \WC_Data_Exception $exception ) {}
+				} catch ( WC_Data_Exception $exception ) {}
 
 			} else {
 


### PR DESCRIPTION
Runs generated SKUs through `wc_product_generate_unique_sku()` (WC 3.0+ only) before saving in case variation attributes have duplicate names. Also generally catches any data exceptions to prevent fatals.

closes #16