### PR TITLE
[ch18871] WC 3.8 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
 Requires at least: 4.4
 Tested up to: 5.2.2
-Stable Tag: 2.4.0
+Stable Tag: 2.4.1-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -154,8 +154,11 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 
 == Changelog ==
 
+= 2019.nn.nn - version 2.4.1-dev.1 =
+ * Misc - Add support for WooCommerce 3.8
+
 = 2019.08.15 - version 2.4.0 =
- * Misc - Add support to WooCommerce 3.7
+ * Misc - Add support for WooCommerce 3.7
  * Misc - Remove support for WooCommerce 2.6
 
 = 2019.06.12 - version 2.3.5 =

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -5,7 +5,7 @@
  * Description: Automatically generate SKUs for products using the product / variation slug and/or ID
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.4.0
+ * Version: 2.4.1-dev.1
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
@@ -19,7 +19,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.8.0
  */
 
 defined( 'ABSPATH' ) or exit;
@@ -45,7 +45,7 @@ class WC_SKU_Generator {
 
 
 	/** plugin version number */
-	const VERSION = '2.4.0';
+	const VERSION = '2.4.1-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This release adds support for WC 3.8.

### Stories

- [CH 18871](https://app.clubhouse.io/skyverge/story/18871/wc-3-8-compatibility)

## Details

Product SKU Generator doesn't use the framework, so this is just a version bump & wc-tested-to bump.

## QA

- Activate WC Admin
- Activate Product SKU Generator
- Enable SKU generation (WC Settings => Product)
- [x] Settings save correctly
- Create a new product or re-save an existing product without a SKU
- [x] SKU is generated correctly

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version