### PR TITLE
WC 3.9 Compatibility Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -154,6 +154,9 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 
 == Changelog ==
 
+= 2020.nn.nn - version 2.4.2-dev.1 =
+ * Misc - Add support for WooCommerce 3.9
+
 = 2019.11.11 - version 2.4.1 =
  * Misc - Add support for WooCommerce 3.8
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
 Requires at least: 4.4
 Tested up to: 5.2.4
-Stable Tag: 2.4.1
+Stable Tag: 2.4.2-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -5,7 +5,7 @@
  * Description: Automatically generate SKUs for products using the product / variation slug and/or ID
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.4.1
+ * Version: 2.4.2-dev.1
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
@@ -45,7 +45,7 @@ class WC_SKU_Generator {
 
 
 	/** plugin version number */
-	const VERSION = '2.4.1';
+	const VERSION = '2.4.2-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -9,13 +9,13 @@
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2014-2019 SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2014-2020, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2014-2019, SkyVerge, Inc.
+ * @copyright Copyright (c) 2014-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9


### PR DESCRIPTION
 # Summary

This PR adds support for WooCommerce 3.9 and updates the copyright year to 2020.

### Stories

- [CH 24724](https://app.clubhouse.io/skyverge/story/24724)

## Details

There were no incompatibilities with WC 3.9.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
