### PR TITLE
Product SKU Generator: Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,7 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 == Changelog ==
 
 = 2020.nn.nn - version 2.4.3 =
+ * Fix - Prevent deprecated notice in PHP 7.4 triggered by calling implode() passing arguments in the wrong order
 
 = 2020.02.05 - version 2.4.2 =
  * Misc - Add support for WooCommerce 3.9

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
 Requires at least: 4.4
 Tested up to: 5.3.2
-Stable Tag: 2.4.2
+Stable Tag: 2.4.3-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -153,6 +153,8 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 `
 
 == Changelog ==
+
+= 2020.nn.nn - version 2.4.3 =
 
 = 2020.02.05 - version 2.4.2 =
  * Misc - Add support for WooCommerce 3.9

--- a/readme.txt
+++ b/readme.txt
@@ -155,7 +155,7 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 == Changelog ==
 
 = 2020.nn.nn - version 2.4.3-dev.1 =
- * Fix - Prevent deprecated notice in PHP 7.4 triggered by calling implode() passing arguments in the wrong order
+ * Fix - Prevent PHP 7.4 deprecated notice while generating variation SKUs
 
 = 2020.02.05 - version 2.4.2 =
  * Misc - Add support for WooCommerce 3.9

--- a/readme.txt
+++ b/readme.txt
@@ -154,7 +154,7 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 
 == Changelog ==
 
-= 2020.nn.nn - version 2.4.3 =
+= 2020.nn.nn - version 2.4.3-dev.1 =
  * Fix - Prevent deprecated notice in PHP 7.4 triggered by calling implode() passing arguments in the wrong order
 
 = 2020.02.05 - version 2.4.2 =

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -5,7 +5,7 @@
  * Description: Automatically generate SKUs for products using the product / variation slug and/or ID
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.4.2
+ * Version: 2.4.3-dev.1
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
@@ -45,7 +45,7 @@ class WC_SKU_Generator {
 
 
 	/** plugin version number */
-	const VERSION = '2.4.2';
+	const VERSION = '2.4.3-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -316,7 +316,7 @@ class WC_SKU_Generator {
 			 */
 			$separator = apply_filters( 'wc_sku_generator_attribute_separator', $this->get_sku_separator() );
 
-			$variation_sku = implode( $variation['attributes'], $separator );
+			$variation_sku = implode( $separator, $variation['attributes'] );
 			$variation_sku = str_replace( 'attribute_', '', $variation_sku );
 		}
 


### PR DESCRIPTION
# Summary

This PR updates the order of arguments on `implode()` calls to prevent Deprecated notices in PHP 7.4

### Stories

- [CH 29451](https://app.clubhouse.io/skyverge/story/29451)

### QA

I think we can limit QA to code review on this one.

- [x] Confirm only implode calls were changed