### PR TITLE
WooCommerce 4.0 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,7 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 == Changelog ==
 
 = 2020.nn.nn - version 2.4.4-dev.1 =
+ * Misc - Add support for WooCommerce 4.0
 
 = 2020.02.12 - version 2.4.3 =
  * Fix - Prevent PHP 7.4 deprecated notice while generating variation SKUs

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
 Requires at least: 4.4
 Tested up to: 5.3.2
-Stable Tag: 2.4.3
+Stable Tag: 2.4.4-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -153,6 +153,8 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 `
 
 == Changelog ==
+
+= 2020.nn.nn - version 2.4.4-dev.1 =
 
 = 2020.02.12 - version 2.4.3 =
  * Fix - Prevent PHP 7.4 deprecated notice while generating variation SKUs

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -5,7 +5,7 @@
  * Description: Automatically generate SKUs for products using the product / variation slug and/or ID
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.4.3
+ * Version: 2.4.4-dev.1
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
@@ -45,7 +45,7 @@ class WC_SKU_Generator {
 
 
 	/** plugin version number */
-	const VERSION = '2.4.3';
+	const VERSION = '2.4.4-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This PR adds support for WooCommerce 4.0.

### Stories

- [CH 31035](https://app.clubhouse.io/skyverge/story/31035/woocommerce-4-0-compatibility)

## Details

There were no incompatibilities with WC 4.0.

## QA

- [x] Save a product and check the SKU being generated accordingly

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version