### PR TITLE
Bumps version number to 2.4.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Automatically generate WooCommerce product SKUs from the product / attribute slu
 
 == Description ==
 
-> **Requires: WooCommerce 3.0.9** or newer
+> **Requires: WooCommerce 3.9.4** or newer
 
 Automatically generate a SKU for parent / simple products, variations, or both when the product is published or updated.
 
@@ -157,6 +157,7 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 = 2022.nn.nn - version 2.4.6-dev.1 =
  * Fix - Avoid uncaught error when saving variable products in certain environments 
  * Misc - Replace calls to deprecated `is_ajax()` with `wp_doing_ajax()`
+ * Misc - Require WooCommerce 3.9.4 or newer
 
 = 2020.05.04 - version 2.4.5 =
  * Misc - Add support for WooCommerce 4.1

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
 Requires at least: 4.4
 Tested up to: 5.4.1
-Stable Tag: 2.4.5
+Stable Tag: 2.4.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -153,6 +153,9 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 `
 
 == Changelog ==
+
+= 2020.05.04 - version 2.4.6 =
+ * Misc - Tests Compatibility with WordPress 5.9.1
 
 = 2020.05.04 - version 2.4.5 =
  * Misc - Add support for WooCommerce 4.1

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -9,13 +9,13 @@
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2014-2020, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2014-2022, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2014-2020, SkyVerge, Inc. (info@skyverge.com)
+ * @copyright Copyright (c) 2014-2022, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -18,7 +18,7 @@
  * @copyright Copyright (c) 2014-2022, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
- * WC requires at least: 3.0.9
+ * WC requires at least: 3.9.4
  * WC tested up to: 4.1.0
  */
 
@@ -48,7 +48,7 @@ class WC_SKU_Generator {
 	const VERSION = '2.4.6-dev.1';
 
 	/** required WooCommerce version number */
-	const MIN_WOOCOMMERCE_VERSION = '3.0.9';
+	const MIN_WOOCOMMERCE_VERSION = '3.9.4';
 
 	/** @var WC_SKU_Generator single instance of this plugin */
 	protected static $instance;

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -5,7 +5,7 @@
  * Description: Automatically generate SKUs for products using the product / variation slug and/or ID
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.4.5
+ * Version: 2.4.6
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
@@ -45,7 +45,7 @@ class WC_SKU_Generator {
 
 
 	/** plugin version number */
-	const VERSION = '2.4.5';
+	const VERSION = '2.4.6';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -73,7 +73,7 @@ class WC_SKU_Generator {
 			add_action( 'woocommerce_ajax_save_product_variations', array( $this, 'ajax_maybe_generate_variation_skus' ) );
 		}
 
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 
 			// add settings
 			add_filter( 'woocommerce_products_general_settings', array( $this, 'add_settings' ) );


### PR DESCRIPTION
# Summary <!-- Required -->
Tests and bumps version number to 2.4.6 and compatible with WordPress 5.9.1

### Issue: [MWC-4387](https://jira.godaddy.com/browse/MWC-4387)

## QA <!-- Optional -->
- [ ] Would like to confirm that this is all that's needed for WordPress plugin repo?

## Before merge <!-- Required -->

- [x] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [x] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code