### PR TITLE
Replace wc_enqueue_js() with inline script

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -156,6 +156,7 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 == Changelog ==
 
 = 2026.nn.nn - version 2.5.1-dev.1 =
+ * Fix - Address `wc_enqueue_js()` deprecation warnings
 
 = 2023.07.28 - version 2.5.0 =
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -77,7 +77,7 @@ class WC_SKU_Generator {
 
 			// add settings
 			add_filter( 'woocommerce_products_general_settings', array( $this, 'add_settings' ) );
-			add_action( 'admin_print_scripts',                   array( $this, 'admin_js' ) );
+			add_action( 'admin_print_footer_scripts',            array( $this, 'admin_js' ), 30 );
 
 			// add plugin links
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'add_plugin_links' ) );
@@ -707,21 +707,22 @@ class WC_SKU_Generator {
 		$current_page = isset( $_GET['page'] ) ? sanitize_text_field( $_GET['page'] ) : '';
 		$current_tab  = isset( $_GET['tab'] )  ? sanitize_text_field( $_GET['tab'] ) : '';
 
-		if ( 'wc-settings' === $current_page && 'products' === $current_tab && empty( $current_section ) ) {
-			wc_enqueue_js(
-				"jQuery(document).ready(function() {
-
-					jQuery( 'select#wc_sku_generator_variation' ).change( function() {
-						if ( jQuery( this ).val() === 'slugs' ) {
-							jQuery( this ).closest('tr').next('tr').show();
-						} else {
-							jQuery( this ).closest('tr').next('tr').hide();
-						}
-					}).change();
-
-				});"
-			);
+		if ( 'wc-settings' !== $current_page || 'products' !== $current_tab || ! empty( $current_section ) ) {
+			return;
 		}
+		?>
+		<script>
+			jQuery( function ( $ ) {
+				$( 'select#wc_sku_generator_variation' ).on( 'change', function () {
+					if ( $( this ).val() === 'slugs' ) {
+						$( this ).closest( 'tr' ).next( 'tr' ).show();
+					} else {
+						$( this ).closest( 'tr' ).next( 'tr' ).hide();
+					}
+				} ).trigger( 'change' );
+			} );
+		</script>
+		<?php
 	}
 
 

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -521,19 +521,25 @@ class WC_SKU_Generator {
 		// only load this script on variable product pages
 		if ( 'never' !== get_option( 'wc_sku_generator_variation' ) && $product instanceof WC_Product && $product->is_type( 'variable' ) ) {
 
-			wc_enqueue_js("
-				var sku = '" . esc_js( __( 'Save product to generate SKU', 'woocommerce-product-sku-generator' ) ) . "';
-				window.disable_variation_sku = function() {
-					$( '.woocommerce_variation .form-field input[name^=\"variable_sku\"]' ).prop( 'readonly', true );
-					$( '.woocommerce_variation .form-field input[name^=\"variable_sku\"]' ).each( function() {
-						if ( $( this ).val().length == 0 ) {
-							$( this ).val( sku );
-						}
-					});
-				}
+			$script_handle = 'woocommerce-product-sku-generator-disable-variation-sku';
+			wp_register_script( $script_handle, false, ['jquery'], WC_SKU_Generator::VERSION, true );
+			wp_enqueue_script( $script_handle );
 
-				$( '#woocommerce-product-data' ).on( 'woocommerce_variations_loaded', disable_variation_sku );
-				$( '#woocommerce-product-data' ).on( 'woocommerce_variations_added', disable_variation_sku );
+			wp_add_inline_script($script_handle, "
+				jQuery(function($) {
+					var sku = '" . esc_js( __( 'Save product to generate SKU', 'woocommerce-product-sku-generator' ) ) . "';
+					window.disable_variation_sku = function() {
+						$( '.woocommerce_variation .form-field input[name^=\"variable_sku\"]' ).prop( 'readonly', true );
+						$( '.woocommerce_variation .form-field input[name^=\"variable_sku\"]' ).each( function() {
+							if ( $( this ).val().length == 0 ) {
+								$( this ).val( sku );
+							}
+						});
+					}
+
+					$( '#woocommerce-product-data' ).on( 'woocommerce_variations_loaded', disable_variation_sku );
+					$( '#woocommerce-product-data' ).on( 'woocommerce_variations_added', disable_variation_sku );
+				});
 			");
 		}
 	}


### PR DESCRIPTION
# Summary

This replaces deprecated `wc_enqueue_js()` calls with inline scripts.

Issue: https://godaddy-corp.atlassian.net/browse/MWC-19383

## QA

1. Edit a variable product.
2. Edit one of the variants.
    - [x] The SKU field is readonly with this message:
<img width="1207" height="141" alt="image" src="https://github.com/user-attachments/assets/26f365a3-b872-4cb8-be5f-c509b8873fc1" />

1. Go to Product Settings.
2. Find the "Generate Variation SKUs:" option.
3. Switch it to "Never"
    - [x] "Replace spaces in attributes?" disappears
4. Switch it to "Use the attribute slugs"
    - [x] "Replace spaces in attributes?" appears
<img width="1182" height="291" alt="image" src="https://github.com/user-attachments/assets/7fc3f462-9810-4d7d-b4cb-ba0e31251ad3" />
