### PR TITLE
Delegate calling install() to init to address "translation loaded too early" errors

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,7 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 
 = 2026.nn.nn - version 2.5.1-dev.1 =
  * Fix - Address `wc_enqueue_js()` deprecation warnings
+ * Fix - Address "translation loaded too early" warnings
 
 = 2023.07.28 - version 2.5.0 =
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -92,7 +92,8 @@ class WC_SKU_Generator {
 			add_action( 'init', array( $this, 'maybe_disable_skus' ) );
 
 			// run every time
-			$this->install();
+			// this runs on init to ensure we don't use translation functions  until they're allowed (init or later)
+			add_action( 'init', [$this, 'install'] );
 		}
 
 		// handle HPOS compatibility
@@ -733,8 +734,9 @@ class WC_SKU_Generator {
 	 * Run every time.  Used since the activation hook is not executed when updating a plugin.
 	 *
 	 * @since 2.0.0
+	 * @internal
 	 */
-	private function install() {
+	public function install() {
 
 		// get current version to check for upgrade
 		$installed_version = get_option( 'wc_sku_generator_version' );


### PR DESCRIPTION
Issue: https://godaddy-corp.atlassian.net/browse/MWC-19601

# Summary

This addresses the following warnings:

> Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the woocommerce-product-sku-generator domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. (This message was added in version 6.7.0.)

Stack trace:

```
_load_textdomain_just_in_time()
wp-includes/l10n.php:1381

get_translations_for_domain()
wp-includes/l10n.php:1419

translate()
wp-includes/l10n.php:195

__()
wp-includes/l10n.php:307

WC_SKU_Generator->get_settings()
wp-content/plugins/woocommerce-product-sku-generator/woocommerce-product-sku-generator.php:583

WC_SKU_Generator->install()
wp-content/plugins/woocommerce-product-sku-generator/woocommerce-product-sku-generator.php:753

WC_SKU_Generator->__construct()
wp-content/plugins/woocommerce-product-sku-generator/woocommerce-product-sku-generator.php:95

WC_SKU_Generator::instance()
wp-content/plugins/woocommerce-product-sku-generator/woocommerce-product-sku-generator.php:133

wc_sku_generator()
wp-content/plugins/woocommerce-product-sku-generator/woocommerce-product-sku-generator.php:819

do_action('plugins_loaded')
wp-settings.php:593
```

The install functions called "get setting" functions, which loaded translation functions.

Install now runs on `init`, which still follows the "always run" intention, but ensures we don't run until after translations are loaded.